### PR TITLE
Reduced allocations on image-conversion if the source image is already

### DIFF
--- a/HPPH.SkiaSharp/ImageExtension.cs
+++ b/HPPH.SkiaSharp/ImageExtension.cs
@@ -21,7 +21,8 @@ public static class ImageExtension
 
         SKBitmap bitmap = new(image.Width, image.Height, SKColorType.Bgra8888, SKAlphaType.Unpremul);
         nint pixelPtr = bitmap.GetPixels(out nint length);
-        image.ConvertTo<ColorBGRA>().CopyTo(new Span<byte>((void*)pixelPtr, (int)length));
+
+        (image as IImage<ColorBGRA> ?? image.ConvertTo<ColorBGRA>()).CopyTo(new Span<byte>((void*)pixelPtr, (int)length));
 
         return bitmap;
     }
@@ -32,9 +33,9 @@ public static class ImageExtension
         return skImage.Encode(SKEncodedImageFormat.Png, 100).ToArray();
     }
 
-    public static IImage ToImage(this SKImage skImage) => SKBitmap.FromImage(skImage).ToImage();
+    public static IImage<ColorBGRA> ToImage(this SKImage skImage) => SKBitmap.FromImage(skImage).ToImage();
 
-    public static IImage ToImage(this SKBitmap bitmap)
+    public static IImage<ColorBGRA> ToImage(this SKBitmap bitmap)
     {
         ArgumentNullException.ThrowIfNull(bitmap, nameof(bitmap));
 

--- a/HPPH.System.Drawing/ImageExtension.cs
+++ b/HPPH.System.Drawing/ImageExtension.cs
@@ -18,10 +18,10 @@ public static class ImageExtension
                     Bitmap bitmap = new(image.Width, image.Height, PixelFormat.Format24bppRgb);
                     BitmapData bmpData = bitmap.LockBits(new Rectangle(0, 0, bitmap.Width, bitmap.Height), ImageLockMode.WriteOnly, bitmap.PixelFormat);
 
-                    IImage<ColorBGR> convertedImage = image.ConvertTo<ColorBGR>();
+                    IImage<ColorBGR> img = image as IImage<ColorBGR> ?? image.ConvertTo<ColorBGR>();
 
                     nint ptr = bmpData.Scan0;
-                    foreach (ImageRow<ColorBGR> row in convertedImage.Rows)
+                    foreach (ImageRow<ColorBGR> row in img.Rows)
                     {
                         row.CopyTo(new Span<byte>((void*)ptr, bmpData.Stride));
                         ptr += bmpData.Stride;
@@ -37,10 +37,10 @@ public static class ImageExtension
                     Bitmap bitmap = new(image.Width, image.Height, PixelFormat.Format32bppArgb);
                     BitmapData bmpData = bitmap.LockBits(new Rectangle(0, 0, bitmap.Width, bitmap.Height), ImageLockMode.WriteOnly, bitmap.PixelFormat);
 
-                    IImage<ColorBGRA> convertedImage = image.ConvertTo<ColorBGRA>();
+                    IImage<ColorBGRA> img = image as IImage<ColorBGRA> ?? image.ConvertTo<ColorBGRA>();
 
                     nint ptr = bmpData.Scan0;
-                    foreach (ImageRow<ColorBGRA> row in convertedImage.Rows)
+                    foreach (ImageRow<ColorBGRA> row in img.Rows)
                     {
                         row.CopyTo(new Span<byte>((void*)ptr, bmpData.Stride));
                         ptr += bmpData.Stride;


### PR DESCRIPTION
in the correct color-format